### PR TITLE
Drop row arrow indicator is not hidden when the drop is no longer val…

### DIFF
--- a/enterprise-edition/EnterpriseColumnLayout.js
+++ b/enterprise-edition/EnterpriseColumnLayout.js
@@ -312,7 +312,9 @@ export default class InovuaDataGridEnterpriseColumnLayout extends InovuaDataGrid
             this.dragRowArrow.setHeight(rowHeight);
             if (dragIndex !== dropIndex && dragIndex + 1 !== dropIndex) {
                 this.setReorderArrowAt(dropIndex, compareRanges);
-            }
+            } else {
+                this.setReorderArrowVisible(false);
+              }
         };
         this.onRowDrop = (event, config, props) => {
             const { dropIndex } = this;

--- a/enterprise-edition/EnterpriseColumnLayout.tsx
+++ b/enterprise-edition/EnterpriseColumnLayout.tsx
@@ -546,6 +546,8 @@ export default class InovuaDataGridEnterpriseColumnLayout extends InovuaDataGrid
 
     if (dragIndex !== dropIndex && dragIndex + 1 !== dropIndex) {
       this.setReorderArrowAt(dropIndex, compareRanges);
+    } else {
+      this.setReorderArrowVisible(false);
     }
   };
 


### PR DESCRIPTION
Issue #108

* Make sure the drop row arrow indicator is hidden when the drop is invalid