### PR TITLE
Fix row reorder arrow style height

### DIFF
--- a/enterprise-edition/EnterpriseColumnLayout.js
+++ b/enterprise-edition/EnterpriseColumnLayout.js
@@ -368,17 +368,19 @@ export default class InovuaDataGridEnterpriseColumnLayout extends InovuaDataGrid
             let box = ranges[index];
             const { contentRegion } = DRAG_INFO;
             let boxPos;
-            let arrowHeight = this.dragRowArrow.props.rowReorderArrowStyle
-                ? Number.parseFloat(this.dragRowArrow.props.rowReorderArrowStyle)
-                : 3;
+            let boxPos = 0;
+            let dragRowArrowHeight = this.dragRowArrow.props.rowReorderArrowStyle ? this.dragRowArrow.props.rowReorderArrowStyle.height : 3;
+      
+            if (!Number.isInteger(dragRowArrowHeight)) {
+              dragRowArrowHeight = 3; // default height set for InovuaReactDataGrid__row-reorder-arrow class
+            }
+      
             if (index === 0) {
                 boxPos = box.top;
-            }
-            else if (index === ranges.length) {
-                boxPos = ranges[ranges.length - 1].bottom - arrowHeight;
-            }
-            else {
-                boxPos = box.top - Math.floor(arrowHeight / 2);
+            } else if (index === ranges.length) {
+                boxPos = ranges[ranges.length - 1].bottom - dragRowArrowHeight;
+            } else {
+                boxPos = box.top - Math.floor(dragRowArrowHeight / 2);
             }
             const arrowPosition = boxPos - contentRegion.top;
             return this.setReorderArrowPosition(arrowPosition);

--- a/enterprise-edition/EnterpriseColumnLayout.tsx
+++ b/enterprise-edition/EnterpriseColumnLayout.tsx
@@ -622,17 +622,20 @@ export default class InovuaDataGridEnterpriseColumnLayout extends InovuaDataGrid
 
     const { contentRegion } = DRAG_INFO;
 
-    let boxPos: number;
-    let arrowHeight: number = this.dragRowArrow.props.rowReorderArrowStyle
-      ? Number.parseFloat(this.dragRowArrow.props.rowReorderArrowStyle)
-      : 3;
+    let boxPos: number = 0;
+
+    let dragRowArrowHeight: number = this.dragRowArrow.props.rowReorderArrowStyle ? this.dragRowArrow.props.rowReorderArrowStyle.height : 3;
+
+    if (!Number.isInteger(dragRowArrowHeight)) {
+      dragRowArrowHeight = 3; // default height set for InovuaReactDataGrid__row-reorder-arrow class
+    }
 
     if (index === 0) {
-      boxPos = box.top;
+        boxPos = box.top;
     } else if (index === ranges.length) {
-      boxPos = ranges[ranges.length - 1].bottom - arrowHeight;
+        boxPos = ranges[ranges.length - 1].bottom - dragRowArrowHeight;
     } else {
-      boxPos = box.top - Math.floor(arrowHeight / 2);
+        boxPos = box.top - Math.floor(dragRowArrowHeight / 2);
     }
 
     const arrowPosition: number = boxPos - contentRegion.top;


### PR DESCRIPTION
My original pull request code was modified and a bug introduced where the height property check was removed. Adding it back.