### PR TITLE
Auto focus on edit escape

### DIFF
--- a/community-edition/factory.js
+++ b/community-edition/factory.js
@@ -1067,6 +1067,7 @@ const GridFactory = ({ plugins } = {}, edition = 'community') => {
         showColumnMenuFilterOptions: true,
         showColumnMenuGroupOptions: true,
         autoFocusOnEditComplete: true,
+        autoFocusOnEditEscape: true,
         showPivotSummaryColumns: true,
         showColumnMenuToolOnHover: !isMobile,
         columnFilterContextMenuConstrainTo: true,

--- a/community-edition/factory.tsx
+++ b/community-edition/factory.tsx
@@ -1617,7 +1617,7 @@ const GridFactory = (
     showColumnMenuFilterOptions: true,
     showColumnMenuGroupOptions: true,
     autoFocusOnEditComplete: true,
-
+    autoFocusOnEditEscape: true,
     showPivotSummaryColumns: true,
     showColumnMenuToolOnHover: !isMobile,
     columnFilterContextMenuConstrainTo: true,

--- a/community-edition/hooks/useRow/index.js
+++ b/community-edition/hooks/useRow/index.js
@@ -23,7 +23,7 @@ export default (props, computedProps, computedPropsRef) => {
         }
         const sameElement = event.target === computedProps.getScrollingElement();
         let handled = false;
-        if (event.key === 'Escape' && !sameElement) {
+        if (event.key === 'Escape' && !sameElement && computedProps.autoFocusOnEditEscape) {
             handled = true;
             computedProps.focus();
         }

--- a/community-edition/hooks/useRow/index.ts
+++ b/community-edition/hooks/useRow/index.ts
@@ -62,7 +62,7 @@ export default (
     const sameElement = event.target === computedProps.getScrollingElement();
 
     let handled: boolean = false;
-    if (event.key === 'Escape' && !sameElement) {
+    if (event.key === 'Escape' && !sameElement && computedProps.autoFocusOnEditEscape) {
       handled = true;
       computedProps.focus();
     }

--- a/community-edition/types/TypeDataGridProps.ts
+++ b/community-edition/types/TypeDataGridProps.ts
@@ -374,6 +374,7 @@ type TypeDataGridPropsNoI18n = {
   preventDefaultTextSelectionOnShiftMouseDown: boolean;
   preventRowSelectionOnClickWithMouseMove: boolean;
   autoFocusOnEditComplete: boolean;
+  autoFocusOnEditEscape: boolean;
   groups?: TypeColumnGroup[];
   activateRowOnFocus: boolean;
   autoCheckboxColumn: boolean;


### PR DESCRIPTION
https://github.com/inovua/reactdatagrid/issues/101

Introduce a property to control whether escaping from editing should automatically give focus to the datagrid row. 

Please feel free to name it differently and also update the documentation.

