### PR TITLE
chore(package): expose types from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/inovua/reactdatagrid/issues"
   },
+  "types": "index.d.ts",
   "main": "index.js",
   "scripts": {
     "// **** run this in dev mode": "****//",


### PR DESCRIPTION
#### Issue:
Unable to use `<ReactDataGrid />` with Typescript project since types isn't exposed from package.json

#### Fix:
Added `type` field to package.json to expose types available within package